### PR TITLE
Update metadata and error messages to include `source`

### DIFF
--- a/Sources/LiveViewNative/Stylesheets/StylesheetParser.swift
+++ b/Sources/LiveViewNative/Stylesheets/StylesheetParser.swift
@@ -9,7 +9,6 @@ struct StylesheetParser<M: ViewModifier & ParseableModifierValue>: Parser {
     let context: ParseableModifierContext
 
     func parse(_ input: inout Substring.UTF8View) throws -> Dictionary<String, Array<M>> {
-        let fullStylesheet = input
         try "%{".utf8.parse(&input)
         // early exit
         if (try? "}".utf8.parse(&input)) != nil {
@@ -24,7 +23,7 @@ struct StylesheetParser<M: ViewModifier & ParseableModifierValue>: Parser {
             try Whitespace().parse(&input)
             do {
                 classes[name] = try ListLiteral {
-                    RecoverableModifier(className: name, fullStylesheet: String(fullStylesheet), context: context)
+                    RecoverableModifier(className: name, context: context)
                 }
                 .parse(&input)
                 .compactMap({ $0 })
@@ -35,10 +34,6 @@ struct StylesheetParser<M: ViewModifier & ParseableModifierValue>: Parser {
                     Stylesheet parsing failed for class `\(name)`:
                     
                     \(error)
-                    
-                    in stylesheet:
-                    
-                    \(String(fullStylesheet) ?? "")
                     """
                 )
                 // consume the rest
@@ -59,7 +54,6 @@ struct StylesheetParser<M: ViewModifier & ParseableModifierValue>: Parser {
     
     struct RecoverableModifier: Parser {
         let className: String
-        let fullStylesheet: String?
         let context: ParseableModifierContext
         
         func parse(_ input: inout Substring.UTF8View) throws -> M? {
@@ -75,10 +69,6 @@ struct StylesheetParser<M: ViewModifier & ParseableModifierValue>: Parser {
                         Stylesheet parsing failed for modifier `\(modifierName)` in class `\(className)`:
                         
                         \(modifierError)
-                        
-                        in stylesheet:
-                        
-                        \(fullStylesheet ?? "")
                         """
                     )
                     return nil

--- a/Sources/LiveViewNative/Stylesheets/StylesheetParser.swift
+++ b/Sources/LiveViewNative/Stylesheets/StylesheetParser.swift
@@ -119,6 +119,15 @@ struct StylesheetParser<M: ViewModifier & ParseableModifierValue>: Parser {
                             AnyArgument(context: context)
                         }
                         .map({ _ in () })
+                        // keyword list
+                        ListLiteral {
+                            Identifier()
+                            Whitespace()
+                            ":".utf8
+                            Whitespace()
+                            AnyArgument(context: context)
+                        }
+                        .map({ _ in () })
                     }
                 }
             }

--- a/Sources/LiveViewNativeStylesheet/ModifierParseError.swift
+++ b/Sources/LiveViewNativeStylesheet/ModifierParseError.swift
@@ -24,11 +24,17 @@ public struct ModifierParseError: Error, CustomDebugStringConvertible {
         var localizedDescription: String {
             switch self {
             case .unknownModifier(let name):
-                "Unknown modifier '\(name)'"
+                return "Unknown modifier `\(name)`"
             case .missingRequiredArgument(let name):
-                "Missing required argument '\(name)'"
+                return "Missing required argument `\(name)`"
             case .noMatchingClause(let name, let clauses):
-                "No matching clause found for modifier '\(name)'. Expected one of \(clauses.map({ "`\(name)(\($0.joined(separator: ":"))\($0.count > 0 ? ":" : ""))`" }).joined(separator: ", "))"
+                if clauses.count == 1,
+                   let clause = clauses.first
+                {
+                    return "No matching clause found for modifier `\(name)`. Expected `\(name)(\(clause.joined(separator: ":"))\(clause.count > 0 ? ":" : ""))`"
+                } else {
+                    return "No matching clause found for modifier `\(name)`. Expected one of \(clauses.map({ "`\(name)(\($0.joined(separator: ":"))\($0.count > 0 ? ":" : ""))`" }).joined(separator: ", "))"
+                }
             }
         }
     }
@@ -38,8 +44,13 @@ public struct ModifierParseError: Error, CustomDebugStringConvertible {
     }
     
     public var localizedDescription: String {
-        """
-        \(metadata.file):\(metadata.module):\(metadata.line): \(error.localizedDescription)
+        let indentation = String(repeating: " ", count: String(metadata.line).count)
+        return """
+        \(indentation) |
+        \(metadata.line) | \(metadata.source)
+        \(indentation) | ^ \(error.localizedDescription)
+        
+        in \(metadata.module) (\(metadata.file):\(metadata.line))
         """
     }
 }

--- a/Sources/LiveViewNativeStylesheet/Parsing/External/Metadata.swift
+++ b/Sources/LiveViewNativeStylesheet/Parsing/External/Metadata.swift
@@ -4,10 +4,11 @@ public struct Metadata {
     public let file: String
     public let line: Int
     public let module: String
+    public let source: String
     
     public static func parser() -> some Parser<Substring.UTF8View, Self> {
-        Parse { (file, line, module) in
-            Self(file: file, line: line, module: module)
+        Parse { (file, line, module, source) in
+            Self(file: file, line: line, module: module, source: source)
         } with: {
             "[".utf8
             
@@ -17,17 +18,17 @@ public struct Metadata {
             StringLiteral()
             Whitespace()
             ",".utf8
-            Whitespace()
             
             Whitespace()
+            
             "line:".utf8
             Whitespace()
             Parsers.IntParser<Substring.UTF8View, Int>()
             Whitespace()
             ",".utf8
-            Whitespace()
             
             Whitespace()
+            
             "module:".utf8
             Whitespace()
             Many {
@@ -36,7 +37,15 @@ public struct Metadata {
                 ".".utf8
             }
             .map({ $0.joined(separator: ".") })
-
+            Whitespace()
+            ",".utf8
+            
+            Whitespace()
+            
+            "source:".utf8
+            Whitespace()
+            StringLiteral()
+            
             Whitespace()
             
             "]".utf8

--- a/Sources/LiveViewNativeStylesheet/Parsing/External/ParseableModifier.swift
+++ b/Sources/LiveViewNativeStylesheet/Parsing/External/ParseableModifier.swift
@@ -51,7 +51,7 @@ public struct StandardExpressionParser<Output: ParseableExpressionProtocol>: Par
 }
 
 public class ParseableModifierContext {
-    public var metadata: Metadata = .init(file: "", line: 0, module: "unknown")
+    public var metadata: Metadata = .init(file: "", line: 0, module: "unknown", source: "<unknown>")
     
     public init() {}
 }


### PR DESCRIPTION
Adds client-side handling for the `source` metadata.